### PR TITLE
[Feat] - 카카오로 회원가입, 로그인 기능 구현

### DIFF
--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/controller/UserController.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/controller/UserController.java
@@ -1,17 +1,18 @@
 package com.hanghae99.catsanddogs.controller;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.hanghae99.catsanddogs.dto.ResponseMessage;
 import com.hanghae99.catsanddogs.dto.user.LoginRequestDto;
 import com.hanghae99.catsanddogs.dto.user.SignupRequestDto;
+import com.hanghae99.catsanddogs.security.jwt.JwtUtil;
+import com.hanghae99.catsanddogs.service.KakaoService;
 import com.hanghae99.catsanddogs.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
@@ -21,6 +22,7 @@ import javax.validation.Valid;
 public class UserController {
 
     private final UserService userService;
+    private final KakaoService kakaoService;
 
     @PostMapping("/signup")
     public ResponseEntity<ResponseMessage> signup(@RequestBody @Valid SignupRequestDto signupRequestDto){
@@ -31,4 +33,19 @@ public class UserController {
     public ResponseEntity<ResponseMessage> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response){
         return userService.login(loginRequestDto, response);
     }
+
+    /*
+    <button id="login-kakao-btn"
+    onclick="location.href='https://kauth.kakao.com/oauth/authorize?client_id=7b1771003e7b65a75c3a5baf1255ce8e
+    &redirect_uri=http://localhost:8080/api/user/kakao/callback&response_type=code'">
+
+    */
+    @GetMapping("/login/kakao")//해당 요청은 프론트에서 직접오는게 아닌 카카오에서 옴
+    public ResponseEntity<ResponseMessage> kakaoLogin(@RequestParam String code
+            , HttpServletResponse response/*kakao에서 받아오기 때문에 response*/)
+            throws JsonProcessingException {
+
+        return kakaoService.kakaoLogin(code, response);
+    }
+
 }

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/dto/user/KakaoUserInfoDto.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/dto/user/KakaoUserInfoDto.java
@@ -1,0 +1,18 @@
+package com.hanghae99.catsanddogs.dto.user;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String email;
+    private String nicknmae;
+
+    public KakaoUserInfoDto(Long id, String nicknmae, String email) {
+        this.id = id;
+        this.nicknmae = nicknmae;
+        this.email = email;
+    }
+}

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/entity/User.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/entity/User.java
@@ -14,12 +14,26 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
+    private Long kakaoId;
+
+    @Column(nullable = false, unique = true)
     private String username;
 
+    @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false, unique = true)
     private String nickname;
 
+    @Column(nullable = false, unique = true)
     private String email;
 
+    //기존 회원이 확인되면 카카오 아이디 업데이트
+    public User kakaoIdUpdate(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
+    }
+
 }
+

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/exception/ErrorCode.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     INVALID_USERNAME_PATTERN("id는 소문자와 숫자 조합 4자리에서 10자리입니다.",400),
     INVALID_PASSWORD_PATTERN("비밀번호는 소문자, 대문자, 숫자, 특수문자(!@#$%^&+=) 조합 8자리에서 15자리입니다.",400),
     DUPLICATE_USERNAME("중복된 아이디가 존재합니다.", 400),
+    DUPLICATE_KAKAO_EMAIL("카카오 계정으로 가입된 회원입니다.", 400),
+    DUPLICATE_EMAIL("해당 이메일로 이미 가입된 회원입니다.", 400),
+    DUPLICATE_NICKNAME("중복된 닉네임이 존재합니다.", 400),
     REQUIRED_ALL("모든 항목이 필수값입니다.",400),
     //404 NOT_FOUND 잘못된 리소스 접근
     CONTENT_NOT_FOUND("존재하지 않는 게시글 입니다.",404),

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/repository/UserRepository.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/repository/UserRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+    Optional<User> findByKakaoId(Long id);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
+
 }

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/service/KakaoService.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/service/KakaoService.java
@@ -1,0 +1,138 @@
+package com.hanghae99.catsanddogs.service;
+
+        import com.fasterxml.jackson.core.JsonProcessingException;
+        import com.fasterxml.jackson.databind.JsonNode;
+        import com.fasterxml.jackson.databind.ObjectMapper;
+        import com.hanghae99.catsanddogs.dto.ResponseMessage;
+        import com.hanghae99.catsanddogs.dto.user.KakaoUserInfoDto;
+        import com.hanghae99.catsanddogs.dto.user.KakaoUserInfoDto;
+        import com.hanghae99.catsanddogs.entity.User;
+        import com.hanghae99.catsanddogs.security.jwt.JwtUtil;
+        import com.hanghae99.catsanddogs.repository.UserRepository;
+        import lombok.RequiredArgsConstructor;
+        import lombok.extern.slf4j.Slf4j;
+        import org.springframework.http.*;
+        import org.springframework.security.crypto.password.PasswordEncoder;
+        import org.springframework.stereotype.Service;
+        import org.springframework.util.LinkedMultiValueMap;
+        import org.springframework.util.MultiValueMap;
+        import org.springframework.web.client.RestTemplate;
+
+        import javax.servlet.http.HttpServletResponse;
+        import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public ResponseEntity<ResponseMessage> kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getToken(code);
+        // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+        // 3. 필요시에 회원가입
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        // 4. JWT 토큰 반환
+        String createToken =  jwtUtil.createToken(kakaoUser.getUsername());
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, createToken);
+        return new ResponseEntity<ResponseMessage>(new ResponseMessage("로그인 성공", 200, null), HttpStatus.OK);
+    }
+
+    // 1. "인가 코드"로 "액세스 토큰" 요청
+    private String getToken(String code) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "4f34fa0d67b1ae315cf02207cee3027a");
+        body.add("redirect_uri", "http://localhost:8080/user/login/kakao");
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        return jsonNode.get("access_token").asText();
+    }
+
+    // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        return new KakaoUserInfoDto(id, nickname, email);
+    }
+
+    // 3. 필요시에 회원가입
+    private User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findByKakaoId(kakaoId)
+                .orElse(null);
+        if (kakaoUser == null) {
+            // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+            if (sameEmailUser != null) {
+                kakaoUser = sameEmailUser;
+                // 기존 회원정보에 카카오 Id 추가
+                kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);
+            } else {
+                // 신규 회원가입
+                // password: random UUID
+                String password = UUID.randomUUID().toString();
+                String encodedPassword = passwordEncoder.encode(password);
+
+                kakaoUser = User.builder()
+                        .nickname(kakaoUserInfo.getNicknmae())
+                        .username(kakaoEmail)
+                        .password(encodedPassword)
+                        .email(kakaoEmail)
+                        .kakaoId(kakaoId).build();
+            }
+
+            userRepository.save(kakaoUser);
+        }
+        return kakaoUser;
+    }
+}

--- a/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/service/UserService.java
+++ b/CatsAndDogs/src/main/java/com/hanghae99/catsanddogs/service/UserService.java
@@ -51,6 +51,19 @@ public class UserService {
         if (checkUser.isPresent()) {
             throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
         }
+        //이메일 중복 확인
+        Optional<User> checkEmail = userRepository.findByEmail(signupRequestDto.getEmail());
+        if (checkEmail.isPresent()) {
+            if(checkEmail.get().getKakaoId() != null){
+                throw new CustomException(ErrorCode.DUPLICATE_KAKAO_EMAIL);
+            }
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        //닉네임 중복 확인
+        Optional<User> checkNickname = userRepository.findByNickname(signupRequestDto.getNickname());
+        if (checkNickname.isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
         //닉네임과 이메일 빈 값 체크
         if(signupRequestDto.getEmail()==null || signupRequestDto.getNickname()==null){
             throw new CustomException(ErrorCode.REQUIRED_ALL);


### PR DESCRIPTION
[Feat] - 카카오로 회원가입, 로그인 기능 구현
1. 유저가 카카오 로그인 시도 시 카카오 계정으로 자동 회원가입
2. 이미 존재하는 카카오 유저일 경우 단순 로그인
3. 카카오 계정으로 이전에 가입된 사람이면 카카오 계정에 카카오 고유 아이디 표시
4. 카카오 유저가 새로운 아이디 생성 시도하면 카카오 유저 메세지 생성
